### PR TITLE
GLES3 To GLES2 + tower_popup position fix + enemy_call bigger size (no issue link)

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -149,4 +149,5 @@ translations=PoolStringArray( "res://resources/localization.en.translation", "re
 
 [rendering]
 
+quality/driver/driver_name="GLES2"
 quality/2d/use_pixel_snap=true

--- a/scenes/enemy-call-button/enemy-call-button.tscn
+++ b/scenes/enemy-call-button/enemy-call-button.tscn
@@ -24,11 +24,10 @@ tracks/0/keys = {
 "times": PoolRealArray( 0, 0.5 ),
 "transitions": PoolRealArray( 1, 1 ),
 "update": 0,
-"values": [ Vector2( 1, 1 ), Vector2( 0.8, 0.8 ) ]
+"values": [ Vector2( 1, 1 ), Vector2( 1.2, 1.2 ) ]
 }
 
 [node name="EnemyCallButton" type="Area2D"]
-visible = false
 script = ExtResource( 3 )
 __meta__ = {
 "_edit_group_": true

--- a/scenes/strategic-point.gd
+++ b/scenes/strategic-point.gd
@@ -13,6 +13,7 @@ onready var audio = $AudioStreamPlayer
 var mouse_inside_area = false
 var last_slot_pressed = null
 
+
 func _ready() -> void:
 	for slot in strategic_point_menu.get_slots():
 		if not slot is Sprite and not slot.tower_resource.locked:
@@ -43,7 +44,7 @@ func hide_strategic_point_menu():
 		Utils.delete_children_from_node(tower_container)
 		sprite.show()
 	last_slot_pressed = null
-
+	tower_description_popup.hide()
 
 func _on_slot_pressed(slot: Slot):
 	if slot != last_slot_pressed:
@@ -60,10 +61,15 @@ func show_tower_description_popup(slot: Slot):
 		slot.tower_resource.fire_rate
 	)
 	var description_appear_pos = slot.rect_global_position
+	print(slot.rect_position.x)
 	if slot.rect_position.x > 0:
 		description_appear_pos.x += slot.rect_size.x
 	else:
 		description_appear_pos.x -= tower_description_popup.rect_size.x
+	if description_appear_pos.y > Game.size.y / 2:
+		description_appear_pos.y -= tower_description_popup.rect_size.y
+	else:
+		description_appear_pos.y += slot.rect_size.y
 	tower_description_popup.show_at_position(description_appear_pos)
 
 

--- a/scenes/ui/tower-description-popup.tscn
+++ b/scenes/ui/tower-description-popup.tscn
@@ -19,6 +19,7 @@ region = Rect2( 481, 323, 32, 32 )
 anchor_right = 1.0
 anchor_bottom = 1.0
 rect_min_size = Vector2( 200, 200 )
+mouse_filter = 2
 theme = ExtResource( 2 )
 script = ExtResource( 3 )
 __meta__ = {
@@ -30,6 +31,7 @@ margin_left = 33.0
 margin_top = 33.0
 margin_right = 1567.0
 margin_bottom = 867.0
+mouse_filter = 2
 custom_constants/margin_right = 10
 custom_constants/margin_top = 10
 custom_constants/margin_left = 10
@@ -43,6 +45,7 @@ margin_left = 10.0
 margin_top = 10.0
 margin_right = 1524.0
 margin_bottom = 824.0
+mouse_filter = 2
 custom_constants/separation = 10
 __meta__ = {
 "_edit_use_anchors_": false
@@ -51,6 +54,7 @@ __meta__ = {
 [node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer/VBoxContainer"]
 margin_right = 1514.0
 margin_bottom = 770.0
+mouse_filter = 2
 size_flags_vertical = 3
 
 [node name="TowerName" type="Label" parent="MarginContainer/VBoxContainer/VBoxContainer"]
@@ -77,17 +81,20 @@ autowrap = true
 margin_top = 780.0
 margin_right = 1514.0
 margin_bottom = 814.0
+mouse_filter = 2
 custom_constants/separation = 5
 
 [node name="AttackPowerContainer" type="HBoxContainer" parent="MarginContainer/VBoxContainer/HBoxContainer"]
 margin_right = 754.0
 margin_bottom = 34.0
+mouse_filter = 2
 size_flags_horizontal = 3
 
 [node name="Icon" type="TextureRect" parent="MarginContainer/VBoxContainer/HBoxContainer/AttackPowerContainer"]
 margin_right = 32.0
 margin_bottom = 34.0
 rect_min_size = Vector2( 32, 32 )
+mouse_filter = 2
 texture = SubResource( 1 )
 expand = true
 stretch_mode = 6
@@ -106,12 +113,14 @@ text = "8-15"
 margin_left = 759.0
 margin_right = 1514.0
 margin_bottom = 34.0
+mouse_filter = 2
 size_flags_horizontal = 3
 
 [node name="Icon" type="TextureRect" parent="MarginContainer/VBoxContainer/HBoxContainer/AttackSpeedContainer"]
 margin_right = 32.0
 margin_bottom = 34.0
 rect_min_size = Vector2( 32, 32 )
+mouse_filter = 2
 texture = SubResource( 2 )
 expand = true
 stretch_mode = 6


### PR DESCRIPTION
Before submitting a Pull Request please read and tick this checkbox:

- [X] I did read the [project licensing](https://github.com/crystal-bit/hacktoberfest-2020#license) and I agree with the content of this Pull Request being licensed under the same conditions.

- Changed the rendering driver from GLES3 to GLES2 (see issue #4)
- Changed the position of the TowerDescriptionPopup that covered the slot if near the screen borders (it's not perfect anyway..) and changed the mouse focus filter so it will disappear on click
- Changed the scale of the animation of the enemy_call_button from 1.0<->0.8 to 1.0<->1.2 for better visibility.
